### PR TITLE
Fix warnings and proxy ShopStyle API via server route

### DIFF
--- a/ecommerce/app/api/shopstyle/route.ts
+++ b/ecommerce/app/api/shopstyle/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const cat = req.nextUrl.searchParams.get("cat") ?? "";
+  const params = new URLSearchParams({
+    abbreviatedCategoryHistogram: "true",
+    limit: "20",
+    cat,
+    view: "web",
+    useElasticsearch: "true",
+    sorts: "Popular",
+    pid: "shopstyle",
+  });
+
+  try {
+    const res = await fetch(
+      `https://api.shopstyle.com/api/v2/products?${params}`,
+      { next: { revalidate: 300 } }
+    );
+    if (!res.ok) return NextResponse.json({ products: [] });
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json({ products: [] });
+  }
+}

--- a/ecommerce/src/components/Collection/Collection.tsx
+++ b/ecommerce/src/components/Collection/Collection.tsx
@@ -13,19 +13,8 @@ export function Collection(props: {
     queryFn: async () => {
       try {
         if (useShopStyle) {
-          const defaultParams = {
-            abbreviatedCategoryHistogram: "true",
-            limit: "20",
-            cat: props.collection,
-            view: "web",
-            useElasticsearch: "true",
-            sorts: "Popular",
-            pid: "shopstyle",
-          };
-
-          const url = "https://api.shopstyle.com/api/v2/products";
-          const params = new URLSearchParams(defaultParams);
-          const response = await fetch(`${url}?${params}`);
+          const params = new URLSearchParams({ cat: props.collection });
+          const response = await fetch(`/api/shopstyle?${params}`);
           if (!response.ok) return [];
           return (await response.json()).products ?? [];
         }

--- a/ecommerce/src/components/ui/productBox.tsx
+++ b/ecommerce/src/components/ui/productBox.tsx
@@ -19,6 +19,7 @@ const ProductBox: React.FC<ProductBoxProps> = ({ productData, dataSource }) => {
           src={product?.images?.[0]?.image}
           alt={product?.images?.[0]?.altText || product?.productName || "Product image"}
           fill={true}
+          sizes="200px"
           style={{ objectFit: dataSource === "Shopstyle" ? "contain" : "cover" }}
           loading="lazy"
         />


### PR DESCRIPTION
### Summary
This PR resolves build/runtime warnings by adding a missing `sizes` prop to the Next.js `Image` component and moves the ShopStyle API call to a server-side proxy route to avoid CORS and client-side exposure issues.

### Problem
The app was generating warnings — notably a missing `sizes` attribute on a Next.js `Image` component using `fill`, and the ShopStyle API was being called directly from the client, which could expose API parameters and trigger CORS issues.

### Solution
- Added a `sizes` prop to the `ProductBox` image to satisfy Next.js image optimization requirements.
- Created a new server-side API route (`/api/shopstyle`) to proxy requests to the ShopStyle API, keeping credentials and parameters server-side and enabling response caching.
- Updated the `Collection` component to call the new internal proxy route instead of the external API directly.

### Key Changes
- **New `/api/shopstyle` route** (`ecommerce/app/api/shopstyle/route.ts`): Proxies GET requests to the ShopStyle API with a 5-minute revalidation cache and graceful error handling.
- **Updated `Collection.tsx`**: Simplified the ShopStyle fetch to call `/api/shopstyle?cat=...` instead of constructing and calling the external URL directly from the client.
- **Updated `productBox.tsx`**: Added `sizes="200px"` to the `Image` component to resolve the Next.js `fill` + missing `sizes` warning.

---

<a href="https://builder.io/app/projects/56b60c92fe0d4894a2f1fdb337457459/dynamic-button-ue93nelp"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://56b60c92fe0d4894a2f1fdb337457459-dynamic-button-ue93nelp_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 98`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>56b60c92fe0d4894a2f1fdb337457459</projectId>-->
<!--<branchName>dynamic-button-ue93nelp</branchName>-->