### PR TITLE
Add component gallery page at /gallery

### DIFF
--- a/ecommerce/app/gallery/page.tsx
+++ b/ecommerce/app/gallery/page.tsx
@@ -1,0 +1,7 @@
+import Gallery from "@/src/components/Gallery/Gallery";
+
+export const dynamic = "force-dynamic";
+
+export default function GalleryPage() {
+  return <Gallery />;
+}

--- a/ecommerce/src/components/Gallery/Gallery.tsx
+++ b/ecommerce/src/components/Gallery/Gallery.tsx
@@ -1,244 +1,425 @@
 /* eslint-disable @next/next/no-img-element */
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
+import Accordion from "@/src/components/Accordion/accordion";
+import AlgoliaSearchBox from "@/src/components/AlgoliaSearchBox/AlgoliaSearchBox";
+import BynderImage from "@/src/components/Blocks/BynderImage";
+import CloudinaryImage from "@/src/components/Blocks/CloudinaryImage";
+import IconCard from "@/src/components/Card/IconCard";
+import ProductCard from "@/src/components/Card/ProductCard";
+import { Collection } from "@/src/components/Collection/Collection";
+import Counter from "@/src/components/Counter/Counter";
+import CustomText from "@/src/components/CustomText";
+import HeroWithChildren from "@/src/components/Hero/HeroWithChildren";
+import ImageHero from "@/src/components/Hero/ImageHero";
+import SplitHero from "@/src/components/Hero/SplitHero";
+import TextHero from "@/src/components/Hero/TextHero";
+import UpsellPopup from "@/src/components/Popup/UpsellPopup";
+import { Button } from "@/src/components/ui/button";
 
-type GalleryItem = {
-  id: string;
-  title: string;
-  category: string;
-  image: string;
-  span: string;
+const heroImage =
+  "https://cdn.builder.io/api/v1/image/assets%2Fa87584e551b6472fa0f0a2eb10f2c0ff%2F61c4f304ac9448b1ad741b83de17e48a";
+const denimImage =
+  "https://cdn.builder.io/api/v1/image/assets%2Fa87584e551b6472fa0f0a2eb10f2c0ff%2F0cde6f8ddd9d482fad53266f8ee0f3ce";
+const builderLogo =
+  "https://cdn.builder.io/static/media/builder-logo.bff0faae.png";
+const headerLogo =
+  "https://cdn.builder.io/api/v1/image/assets%2Fa87584e551b6472fa0f0a2eb10f2c0ff%2F692369ff646645349e68a86b43fc7a38";
+
+const sampleProduct = {
+  data: {
+    handle: "gallery-sample-product",
+    productName: "Studio Denim Jacket",
+    price: 128,
+    colors: [{ label: "Light wash" }],
+    images: [
+      {
+        image: denimImage,
+        altText: "Denim jacket product preview",
+      },
+    ],
+  },
 };
 
-const items: GalleryItem[] = [
+const navSections = [
   {
-    id: "1",
-    title: "Essential Accessories",
-    category: "Accessories",
-    image:
-      "https://images.unsplash.com/photo-1490481651871-ab68de25d43d?auto=format&fit=crop&w=900&q=80",
-    span: "md:row-span-2",
+    title: "Heros",
+    items: ["ImageHero", "SplitHero", "TextHero", "HeroWithChildren"],
   },
   {
-    id: "2",
-    title: "Tailored Layers",
-    category: "Men",
-    image:
-      "https://images.unsplash.com/photo-1516257984-b1b4d707412e?auto=format&fit=crop&w=900&q=80",
-    span: "",
+    title: "Cards",
+    items: ["IconCard", "ProductCard"],
   },
   {
-    id: "3",
-    title: "Soft Knits",
-    category: "Women",
-    image:
-      "https://images.unsplash.com/photo-1539109136881-3be0616acf4b?auto=format&fit=crop&w=900&q=80",
-    span: "",
+    title: "Commerce",
+    items: ["Collection", "AlgoliaSearchBox"],
   },
   {
-    id: "4",
-    title: "Studio Edit",
-    category: "Women",
-    image:
-      "https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?auto=format&fit=crop&w=900&q=80",
-    span: "md:row-span-2",
+    title: "Media",
+    items: ["CloudinaryImage", "BynderImage"],
   },
   {
-    id: "5",
-    title: "Everyday Carry",
-    category: "Accessories",
-    image:
-      "https://images.unsplash.com/photo-1553062407-98eeb64c6a62?auto=format&fit=crop&w=900&q=80",
-    span: "",
+    title: "Utility",
+    items: ["Accordion", "Counter", "UpsellPopup", "Core:Button"],
   },
   {
-    id: "6",
-    title: "Urban Uniform",
-    category: "Men",
-    image:
-      "https://images.unsplash.com/photo-1483985988355-763728e1935b?auto=format&fit=crop&w=900&q=80",
-    span: "",
-  },
-  {
-    id: "7",
-    title: "Summer Sale",
-    category: "Sale",
-    image:
-      "https://images.unsplash.com/photo-1485462537746-965f33f7f6a7?auto=format&fit=crop&w=900&q=80",
-    span: "md:col-span-2",
-  },
-  {
-    id: "8",
-    title: "Minimal Footwear",
-    category: "Accessories",
-    image:
-      "https://images.unsplash.com/photo-1460353581641-37baddab0fa2?auto=format&fit=crop&w=900&q=80",
-    span: "",
-  },
-  {
-    id: "9",
-    title: "The Denim Story",
-    category: "Women",
-    image:
-      "https://images.unsplash.com/photo-1542272604-787c3835535d?auto=format&fit=crop&w=900&q=80",
-    span: "md:row-span-2",
-  },
-  {
-    id: "10",
-    title: "Cold Weather",
-    category: "Men",
-    image:
-      "https://images.unsplash.com/photo-1521223890158-f9f7c3d5d504?auto=format&fit=crop&w=900&q=80",
-    span: "",
-  },
-  {
-    id: "11",
-    title: "Off Duty",
-    category: "Women",
-    image:
-      "https://images.unsplash.com/photo-1496747611176-843222e1e57c?auto=format&fit=crop&w=900&q=80",
-    span: "",
-  },
-  {
-    id: "12",
-    title: "Final Markdowns",
-    category: "Sale",
-    image:
-      "https://images.unsplash.com/photo-1445205170230-053b83016050?auto=format&fit=crop&w=900&q=80",
-    span: "",
+    title: "Text",
+    items: ["Custom Text"],
   },
 ];
 
-const categories = ["All", "Women", "Men", "Accessories", "Sale"];
+function slugify(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+}
+
+function ComponentSection({
+  name,
+  group,
+  description,
+  inputs,
+  children,
+}: {
+  name: string;
+  group: string;
+  description: string;
+  inputs: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={slugify(name)} className="scroll-mt-6 border-b border-zinc-200 bg-white">
+      <div className="border-b border-zinc-200 bg-white px-5 py-4">
+        <div className="flex items-center gap-2 text-xs text-zinc-500">
+          <span>{group}</span>
+          <span>/</span>
+          <h2 className="text-2xl font-semibold text-black tracking-tight">{name}</h2>
+        </div>
+        <p className="mt-4 text-sm text-zinc-600">{description}</p>
+        <p className="mt-2 text-xs uppercase tracking-[2px] text-zinc-500">
+          Inputs <span className="normal-case tracking-normal text-zinc-700">{inputs}</span>
+        </p>
+      </div>
+      <div className="bg-zinc-50 px-5 py-3 text-xs font-medium text-zinc-700">
+        <span className="mr-2 inline-flex h-5 w-5 items-center justify-center rounded-full border border-zinc-300 bg-white text-[10px]">
+          1
+        </span>
+        Example
+      </div>
+      <div className="p-5">{children}</div>
+    </section>
+  );
+}
+
+function PlaceholderPreview({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-[180px] items-center justify-center rounded-md border border-dashed border-zinc-300 bg-white p-6 text-center text-sm text-zinc-500">
+      {children}
+    </div>
+  );
+}
 
 export default function Gallery() {
-  const [activeCategory, setActiveCategory] = useState("All");
-  const [activeItem, setActiveItem] = useState<GalleryItem | null>(null);
-
-  const filtered =
-    activeCategory === "All"
-      ? items
-      : items.filter((item) => item.category === activeCategory);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setActiveItem(null);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, []);
-
   return (
-    <section className="flex flex-col mt-4 mb-12">
-      <div className="flex flex-col items-center text-center mb-8">
-        <p className="text-sm uppercase tracking-[3px] text-zinc-500">
-          Lookbook
-        </p>
-        <h1 className="text-3xl md:text-4xl uppercase tracking-[6px] mt-2">
-          Gallery
-        </h1>
-        <p className="max-w-xl mt-4 text-sm text-zinc-500">
-          A curated edit of the season&apos;s essentials. Explore the looks and
-          shop the pieces that define the collection.
-        </p>
-      </div>
-
-      <div className="flex flex-wrap justify-center gap-2 mb-8">
-        {categories.map((category) => (
-          <button
-            key={category}
-            type="button"
-            onClick={() => setActiveCategory(category)}
-            className={`px-4 py-1.5 text-xs uppercase tracking-[2px] rounded-full border transition-colors ${
-              activeCategory === category
-                ? "bg-black text-white border-black"
-                : "bg-transparent text-zinc-600 border-zinc-300 hover:border-zinc-500"
-            }`}
-          >
-            {category}
-          </button>
-        ))}
-      </div>
-
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4 auto-rows-[220px] md:auto-rows-[260px]">
-        {filtered.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            onClick={() => setActiveItem(item)}
-            className={`group relative overflow-hidden rounded-md bg-zinc-100 text-left ${item.span}`}
-          >
-            <img
-              loading="lazy"
-              src={item.image}
-              alt={item.title}
-              className="object-cover w-full h-full transition-transform duration-500 group-hover:scale-105"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/0 to-black/0 opacity-80 transition-opacity group-hover:opacity-100" />
-            <div className="absolute inset-x-0 bottom-0 p-4 flex flex-col items-start">
-              <span
-                className={`text-[10px] uppercase tracking-[2px] ${
-                  item.category === "Sale" ? "text-rose-400" : "text-white/80"
-                }`}
-              >
-                {item.category}
-              </span>
-              <span className="text-white text-sm md:text-base uppercase tracking-[2px]">
-                {item.title}
-              </span>
-            </div>
-          </button>
-        ))}
-      </div>
-
-      {activeItem && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
-          onClick={() => setActiveItem(null)}
-        >
-          <div
-            className="relative max-w-3xl w-full bg-white rounded-md overflow-hidden"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button
-              type="button"
-              onClick={() => setActiveItem(null)}
-              aria-label="Close"
-              className="absolute top-3 right-3 z-10 flex items-center justify-center w-9 h-9 rounded-full bg-white/90 text-black hover:bg-white"
-            >
-              ✕
-            </button>
-            <img
-              src={activeItem.image}
-              alt={activeItem.title}
-              className="object-cover w-full max-h-[70vh]"
-            />
-            <div className="flex items-center justify-between p-5">
-              <div className="flex flex-col">
-                <span
-                  className={`text-[10px] uppercase tracking-[2px] ${
-                    activeItem.category === "Sale"
-                      ? "text-rose-500"
-                      : "text-zinc-500"
-                  }`}
-                >
-                  {activeItem.category}
-                </span>
-                <span className="text-lg uppercase tracking-[3px]">
-                  {activeItem.title}
-                </span>
+    <div className="mb-12 flex min-h-screen rounded-md border border-zinc-200 bg-white">
+      <aside className="hidden w-64 shrink-0 border-r border-zinc-200 bg-zinc-50 md:block">
+        <div className="sticky top-0 p-5">
+          <div className="mb-8">
+            <p className="text-xs font-semibold uppercase tracking-[2px] text-rose-500">
+              Builder CMS
+            </p>
+            <p className="text-xs text-zinc-500">Component Gallery</p>
+          </div>
+          <nav className="space-y-7" aria-label="Component gallery">
+            {navSections.map((section) => (
+              <div key={section.title}>
+                <p className="mb-2 text-[11px] font-semibold uppercase tracking-[2px] text-zinc-500">
+                  {section.title}
+                </p>
+                <div className="space-y-1">
+                  {section.items.map((item) => (
+                    <a
+                      key={item}
+                      href={`#${slugify(item)}`}
+                      className="block border-l-2 border-transparent px-3 py-1.5 text-sm font-medium text-zinc-700 hover:border-rose-500 hover:bg-rose-50 hover:text-rose-600"
+                    >
+                      {item}
+                    </a>
+                  ))}
+                </div>
               </div>
-              <a
-                href={`/category/${activeItem.category.toLowerCase()}`}
-                className="text-xs uppercase tracking-[2px] border border-black px-5 py-2.5 hover:bg-black hover:text-white transition-colors"
-              >
-                Shop Now
-              </a>
+            ))}
+          </nav>
+        </div>
+      </aside>
+
+      <main className="min-w-0 flex-1">
+        <div className="border-b border-zinc-200 bg-white px-5 py-6">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-[3px] text-zinc-500">Sections</p>
+              <h1 className="mt-1 text-3xl font-semibold tracking-tight">Component Gallery</h1>
+              <p className="mt-3 max-w-3xl text-sm text-zinc-600">
+                Live examples of the custom components registered in this repo for Builder.io content authoring.
+              </p>
             </div>
+            <span className="w-fit rounded-full border border-zinc-300 px-3 py-1 text-xs text-zinc-600">
+              15 components
+            </span>
           </div>
         </div>
-      )}
-    </section>
+
+        <ComponentSection
+          name="ImageHero"
+          group="Heros"
+          description="Full-width image hero with headline, rich text subtitle, alignment options, and a CTA button."
+          inputs="title, alignment, backgroundImage, buttonText, buttonLink, subTitle, makeFullBleed"
+        >
+          <ImageHero
+            title="SHOP ESSENTIALS"
+            subTitle="<p>Shoppable essentials for your every day life.</p>"
+            buttonText="Shop Now"
+            buttonLink="/category/accessories"
+            backgroundImage={heroImage}
+            alignment="right"
+            makeFullBleed={false}
+          />
+        </ComponentSection>
+
+        <ComponentSection
+          name="SplitHero"
+          group="Heros"
+          description="Two-column hero pairing editorial text with an image, configurable image side, split width, text alignment, and CTA."
+          inputs="imageAlignment, textAlignment, splitWidth, image, altText, title, subTitle, hasCTA, buttonText, buttonLink, makeFullBleed"
+        >
+          <SplitHero
+            imageAlignment="left"
+            textAlignment="left"
+            splitWidth="1/2"
+            title="OUR COMMITMENT TO SUSTAINABILITY"
+            subTitle="<p>Create impactful, bold silhouettes in our chic, cozy classics.</p>"
+            image={denimImage}
+            altText="Blue denim apparel"
+            hasCTA={true}
+            buttonText="Learn More"
+            buttonLink="/about"
+            makeFullBleed={false}
+          />
+        </ComponentSection>
+
+        <ComponentSection
+          name="TextHero"
+          group="Heros"
+          description="Centered text-only hero for short editorial statements or page introductions."
+          inputs="title, subTitle"
+        >
+          <TextHero
+            title="STEP INTO FRESH STYLES"
+            subTitle="<p>Lightweight layers, polished basics, and accessories made for everyday wear.</p>"
+          />
+        </ComponentSection>
+
+        <ComponentSection
+          name="HeroWithChildren"
+          group="Heros"
+          description="Hero wrapper that accepts up to three Builder child blocks underneath a header."
+          inputs="header, childBlocks, makeFullBleed"
+        >
+          <HeroWithChildren
+            header="WHAT'S DIFFERENT ABOUT SHOPAHOLIC"
+            childBlocks={[]}
+            makeFullBleed={false}
+          />
+        </ComponentSection>
+
+        <ComponentSection
+          name="IconCard"
+          group="Cards"
+          description="Small marketing card with icon, title, rich text description, alignment, and optional colored background."
+          inputs="icon, altText, title, description, alignment, coloredBackground"
+        >
+          <div className="grid gap-4 md:grid-cols-3">
+            <IconCard
+              icon={builderLogo}
+              altText="Builder.io logo"
+              title="Composable Content"
+              description="<p>Give teams reusable blocks that match the storefront experience.</p>"
+              alignment="center"
+              coloredBackground={false}
+            />
+            <IconCard
+              icon={builderLogo}
+              altText="Builder.io logo"
+              title="Visual Editing"
+              description="<p>Preview components exactly as shoppers will see them.</p>"
+              alignment="left"
+              coloredBackground={true}
+            />
+            <IconCard
+              icon={builderLogo}
+              altText="Builder.io logo"
+              title="Reusable Systems"
+              description="<p>Build pages from well-defined component primitives.</p>"
+              alignment="right"
+              coloredBackground={false}
+            />
+          </div>
+        </ComponentSection>
+
+        <ComponentSection
+          name="ProductCard"
+          group="Cards"
+          description="Product tile that can render products from Builder, Shopify, Swell, Commercetools, or Emporix."
+          inputs="dataSource, product, shopifyProductHandle, swellProductHandle, commercetoolsProduct, emporixProductHandle"
+        >
+          <div className="max-w-xs">
+            <ProductCard product={sampleProduct} dataSource="Builder" />
+          </div>
+        </ComponentSection>
+
+        <ComponentSection
+          name="Collection"
+          group="Commerce"
+          description="Horizontally scrolling product collection sourced from Builder product data and filtered by collection."
+          inputs="collection"
+        >
+          <Collection collection="all" />
+        </ComponentSection>
+
+        <ComponentSection
+          name="AlgoliaSearchBox"
+          group="Commerce"
+          description="Algolia-powered product search with category, color, and size refinements."
+          inputs="none"
+        >
+          <AlgoliaSearchBox />
+        </ComponentSection>
+
+        <ComponentSection
+          name="CloudinaryImage"
+          group="Media"
+          description="Custom image block that renders a selected Cloudinary asset from Builder's Cloudinary image editor input."
+          inputs="cloudinaryOptions"
+        >
+          <div className="max-w-sm rounded-md border border-zinc-200 bg-white p-6">
+            <CloudinaryImage
+              cloudinaryOptions={{
+                url: "https://res.cloudinary.com/cloudinary-marketing/image/upload/v1599098500/creative_source/Logo/Cloud%20Glyph/cloudinary_cloud_glyph_blue_png.png",
+                width: 160,
+                height: 120,
+                alt: "Cloudinary logo",
+                name: "Cloudinary logo",
+              }}
+            />
+          </div>
+        </ComponentSection>
+
+        <ComponentSection
+          name="BynderImage"
+          group="Media"
+          description="Custom image block that renders a selected Bynder asset with configurable image fit."
+          inputs="bynderAsset, imageFit"
+        >
+          <div className="max-w-md overflow-hidden rounded-md border border-zinc-200 bg-white">
+            <BynderImage
+              imageFit="cover"
+              bynderAsset={{
+                assets: [
+                  {
+                    description: "Builder storefront asset",
+                    files: {
+                      webImage: {
+                        url: heroImage,
+                        width: 900,
+                        height: 600,
+                      },
+                    },
+                  } as any,
+                ],
+              }}
+            />
+          </div>
+        </ComponentSection>
+
+        <ComponentSection
+          name="Accordion"
+          group="Utility"
+          description="Simple expandable content list for FAQs or dense page sections."
+          inputs="items"
+        >
+          <Accordion
+            items={[
+              { title: "What can be edited?", content: "Titles, body content, images, and layout options." },
+              { title: "Where is it registered?", content: "This component is registered in src/builder-registry.ts." },
+              { title: "How is it used?", content: "Add it from Builder's insert menu and configure the item list." },
+            ]}
+          />
+        </ComponentSection>
+
+        <ComponentSection
+          name="Counter"
+          group="Utility"
+          description="Interactive counter component with a configurable initial value."
+          inputs="initialCount"
+        >
+          <Counter initialCount={3} />
+        </ComponentSection>
+
+        <ComponentSection
+          name="UpsellPopup"
+          group="Utility"
+          description="Timed promotional modal with discount options, image, title, subtitle, and dismiss action."
+          inputs="title, subTitle, delay, discountLabel, discounts, imageSrc, imageAlt"
+        >
+          <PlaceholderPreview>
+            This component renders as a timed modal. The live modal is included here with a long delay so it does not interrupt browsing the gallery.
+          </PlaceholderPreview>
+          <UpsellPopup
+            title="Special Offer"
+            subTitle="Save up to 50%"
+            delay={9999999}
+            discountLabel="Select your discount:"
+            discounts={[{ label: "15% Off" }, { label: "Free Shipping" }]}
+            imageSrc={headerLogo}
+            imageAlt="Builder.io logo"
+          />
+        </ComponentSection>
+
+        <ComponentSection
+          name="Core:Button"
+          group="Utility"
+          description="Project-styled Button override registered for Builder content with common storefront variants."
+          inputs="variant, children"
+        >
+          <div className="flex flex-wrap gap-3">
+            <Button variant="default">Default</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="tertiary">Tertiary</Button>
+            <Button variant="outline">Outline</Button>
+            <Button variant="link">Link</Button>
+          </div>
+        </ComponentSection>
+
+        <ComponentSection
+          name="Custom Text"
+          group="Text"
+          description="Rich text renderer that rewrites configured placeholder links to referenced product URLs."
+          inputs="text, links"
+        >
+          <div className="rounded-md border border-zinc-200 bg-white p-6 text-base leading-7">
+            <CustomText
+              text={'<p>Build content with inline product links like <a href="#featured-product">this featured product</a>.</p>'}
+              links={[
+                {
+                  key: "featured-product",
+                  label: "Studio Denim Jacket",
+                  target: "_self",
+                  product: { value: { data: { handle: "gallery-sample-product" } } },
+                },
+              ]}
+            />
+          </div>
+        </ComponentSection>
+      </main>
+    </div>
   );
 }

--- a/ecommerce/src/components/Gallery/Gallery.tsx
+++ b/ecommerce/src/components/Gallery/Gallery.tsx
@@ -1,0 +1,244 @@
+/* eslint-disable @next/next/no-img-element */
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+type GalleryItem = {
+  id: string;
+  title: string;
+  category: string;
+  image: string;
+  span: string;
+};
+
+const items: GalleryItem[] = [
+  {
+    id: "1",
+    title: "Essential Accessories",
+    category: "Accessories",
+    image:
+      "https://images.unsplash.com/photo-1490481651871-ab68de25d43d?auto=format&fit=crop&w=900&q=80",
+    span: "md:row-span-2",
+  },
+  {
+    id: "2",
+    title: "Tailored Layers",
+    category: "Men",
+    image:
+      "https://images.unsplash.com/photo-1516257984-b1b4d707412e?auto=format&fit=crop&w=900&q=80",
+    span: "",
+  },
+  {
+    id: "3",
+    title: "Soft Knits",
+    category: "Women",
+    image:
+      "https://images.unsplash.com/photo-1539109136881-3be0616acf4b?auto=format&fit=crop&w=900&q=80",
+    span: "",
+  },
+  {
+    id: "4",
+    title: "Studio Edit",
+    category: "Women",
+    image:
+      "https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?auto=format&fit=crop&w=900&q=80",
+    span: "md:row-span-2",
+  },
+  {
+    id: "5",
+    title: "Everyday Carry",
+    category: "Accessories",
+    image:
+      "https://images.unsplash.com/photo-1553062407-98eeb64c6a62?auto=format&fit=crop&w=900&q=80",
+    span: "",
+  },
+  {
+    id: "6",
+    title: "Urban Uniform",
+    category: "Men",
+    image:
+      "https://images.unsplash.com/photo-1483985988355-763728e1935b?auto=format&fit=crop&w=900&q=80",
+    span: "",
+  },
+  {
+    id: "7",
+    title: "Summer Sale",
+    category: "Sale",
+    image:
+      "https://images.unsplash.com/photo-1485462537746-965f33f7f6a7?auto=format&fit=crop&w=900&q=80",
+    span: "md:col-span-2",
+  },
+  {
+    id: "8",
+    title: "Minimal Footwear",
+    category: "Accessories",
+    image:
+      "https://images.unsplash.com/photo-1460353581641-37baddab0fa2?auto=format&fit=crop&w=900&q=80",
+    span: "",
+  },
+  {
+    id: "9",
+    title: "The Denim Story",
+    category: "Women",
+    image:
+      "https://images.unsplash.com/photo-1542272604-787c3835535d?auto=format&fit=crop&w=900&q=80",
+    span: "md:row-span-2",
+  },
+  {
+    id: "10",
+    title: "Cold Weather",
+    category: "Men",
+    image:
+      "https://images.unsplash.com/photo-1521223890158-f9f7c3d5d504?auto=format&fit=crop&w=900&q=80",
+    span: "",
+  },
+  {
+    id: "11",
+    title: "Off Duty",
+    category: "Women",
+    image:
+      "https://images.unsplash.com/photo-1496747611176-843222e1e57c?auto=format&fit=crop&w=900&q=80",
+    span: "",
+  },
+  {
+    id: "12",
+    title: "Final Markdowns",
+    category: "Sale",
+    image:
+      "https://images.unsplash.com/photo-1445205170230-053b83016050?auto=format&fit=crop&w=900&q=80",
+    span: "",
+  },
+];
+
+const categories = ["All", "Women", "Men", "Accessories", "Sale"];
+
+export default function Gallery() {
+  const [activeCategory, setActiveCategory] = useState("All");
+  const [activeItem, setActiveItem] = useState<GalleryItem | null>(null);
+
+  const filtered =
+    activeCategory === "All"
+      ? items
+      : items.filter((item) => item.category === activeCategory);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setActiveItem(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  return (
+    <section className="flex flex-col mt-4 mb-12">
+      <div className="flex flex-col items-center text-center mb-8">
+        <p className="text-sm uppercase tracking-[3px] text-zinc-500">
+          Lookbook
+        </p>
+        <h1 className="text-3xl md:text-4xl uppercase tracking-[6px] mt-2">
+          Gallery
+        </h1>
+        <p className="max-w-xl mt-4 text-sm text-zinc-500">
+          A curated edit of the season&apos;s essentials. Explore the looks and
+          shop the pieces that define the collection.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap justify-center gap-2 mb-8">
+        {categories.map((category) => (
+          <button
+            key={category}
+            type="button"
+            onClick={() => setActiveCategory(category)}
+            className={`px-4 py-1.5 text-xs uppercase tracking-[2px] rounded-full border transition-colors ${
+              activeCategory === category
+                ? "bg-black text-white border-black"
+                : "bg-transparent text-zinc-600 border-zinc-300 hover:border-zinc-500"
+            }`}
+          >
+            {category}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-4 auto-rows-[220px] md:auto-rows-[260px]">
+        {filtered.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => setActiveItem(item)}
+            className={`group relative overflow-hidden rounded-md bg-zinc-100 text-left ${item.span}`}
+          >
+            <img
+              loading="lazy"
+              src={item.image}
+              alt={item.title}
+              className="object-cover w-full h-full transition-transform duration-500 group-hover:scale-105"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/0 to-black/0 opacity-80 transition-opacity group-hover:opacity-100" />
+            <div className="absolute inset-x-0 bottom-0 p-4 flex flex-col items-start">
+              <span
+                className={`text-[10px] uppercase tracking-[2px] ${
+                  item.category === "Sale" ? "text-rose-400" : "text-white/80"
+                }`}
+              >
+                {item.category}
+              </span>
+              <span className="text-white text-sm md:text-base uppercase tracking-[2px]">
+                {item.title}
+              </span>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {activeItem && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+          onClick={() => setActiveItem(null)}
+        >
+          <div
+            className="relative max-w-3xl w-full bg-white rounded-md overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              onClick={() => setActiveItem(null)}
+              aria-label="Close"
+              className="absolute top-3 right-3 z-10 flex items-center justify-center w-9 h-9 rounded-full bg-white/90 text-black hover:bg-white"
+            >
+              ✕
+            </button>
+            <img
+              src={activeItem.image}
+              alt={activeItem.title}
+              className="object-cover w-full max-h-[70vh]"
+            />
+            <div className="flex items-center justify-between p-5">
+              <div className="flex flex-col">
+                <span
+                  className={`text-[10px] uppercase tracking-[2px] ${
+                    activeItem.category === "Sale"
+                      ? "text-rose-500"
+                      : "text-zinc-500"
+                  }`}
+                >
+                  {activeItem.category}
+                </span>
+                <span className="text-lg uppercase tracking-[3px]">
+                  {activeItem.title}
+                </span>
+              </div>
+              <a
+                href={`/category/${activeItem.category.toLowerCase()}`}
+                className="text-xs uppercase tracking-[2px] border border-black px-5 py-2.5 hover:bg-black hover:text-white transition-colors"
+              >
+                Shop Now
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
### Summary
Adds a new `/gallery` route that showcases all custom Builder.io components registered in this repo, with live rendered examples and a left-side navigation panel for quick access.

### Problem
There was no central place to browse and visually inspect the custom components available in this project, making it difficult for content authors and developers to discover what components exist and how they look.

### Solution
Created a dedicated `/gallery` page with a sticky left-side sub-nav organized by component group, and a main content area where each component is rendered with a live example, description, and input reference.

### Key Changes
- **`app/gallery/page.tsx`** — New Next.js page route at `/gallery` that renders the `Gallery` component with `force-dynamic` export
- **`src/components/Gallery/Gallery.tsx`** — New client component containing:
  - Sticky left sidebar nav with sections: Heros, Cards, Commerce, Media, Utility, and Text
  - `ComponentSection` wrapper that displays each component's name, group, description, and inputs alongside a live example
  - `PlaceholderPreview` helper for components (e.g. `UpsellPopup`) that can't be rendered inline without side effects
  - Live examples for all 15 registered components: `ImageHero`, `SplitHero`, `TextHero`, `HeroWithChildren`, `IconCard`, `ProductCard`, `Collection`, `AlgoliaSearchBox`, `CloudinaryImage`, `BynderImage`, `Accordion`, `Counter`, `UpsellPopup`, `Core:Button`, and `CustomText`
  - Anchor-based navigation using a `slugify` utility for smooth scroll-to-section behavior


---

<a href="https://builder.io/app/projects/3b9fc7c601564aab9df9/warm-entrance-jpyfehpr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://3b9fc7c601564aab9df9-warm-entrance-jpyfehpr.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=3b9fc7c601564aab9df9&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 103`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3b9fc7c601564aab9df9</projectId>-->
<!--<branchName>warm-entrance-jpyfehpr</branchName>-->