### PR TITLE
Fix runtime error from localized nav label object in Header

### DIFF
--- a/ecommerce/src/components/Layout/Header.tsx
+++ b/ecommerce/src/components/Layout/Header.tsx
@@ -15,6 +15,12 @@ import { CartSlider } from "./CartSlider"
 import { SideNav } from "./SideNav"
 import { BuilderContent } from '@builder.io/react';
 
+function getLocalizedValue(value: any, locale = "en-US") {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value[locale] ?? value.Default ?? "";
+  }
+  return value;
+}
 
 export function Header({ headerContent }: any) {
   return (
@@ -44,7 +50,7 @@ export function Header({ headerContent }: any) {
                     <Button key={index} variant="link" className="text-md">
                       <Link href={item.path || '/'} legacyBehavior passHref >
                         {/* <NavigationMenuLink className={navigationMenuTriggerStyle()}> */}
-                        <span className={`uppercase ${item.highlight ? "text-rose-500" : ""}`}>{item.label}</span>
+                        <span className={`uppercase ${item.highlight ? "text-rose-500" : ""}`}>{getLocalizedValue(item.label)}</span>
                         {/* </NavigationMenuLink> */}
                       </Link>
                     </Button>


### PR DESCRIPTION
### Summary
Fixes a runtime error in the `Header` component caused by rendering a localized label object directly as React children.

### Problem
Navigation item labels could be objects containing locale-specific values (e.g. `{ "en-US": "...", "Default": "..." }`) rather than plain strings. Rendering such an object directly inside a `span` caused a runtime error.

### Solution
Added a helper function to resolve the correct localized string value from the label object before rendering, falling back to a default locale or default value when needed.

### Key Changes
- Added `getLocalizedValue` helper in `Header.tsx` that extracts a string from a locale-keyed object (defaulting to `"en-US"`, falling back to `Default`, or returning the value as-is if it's not an object).
- Updated the nav item label rendering to use `getLocalizedValue(item.label)` instead of rendering `item.label` directly.

---

<a href="https://builder.io/app/projects/7e3c100e16b046469904/semi-pod-s8a6b52y"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://7e3c100e16b046469904-semi-pod-s8a6b52y.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=7e3c100e16b046469904&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 106`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7e3c100e16b046469904</projectId>-->
<!--<branchName>semi-pod-s8a6b52y</branchName>-->