### PR TITLE
Add flip animation to product cards on hover

### DIFF
--- a/ecommerce/src/components/ui/productBox.tsx
+++ b/ecommerce/src/components/ui/productBox.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { useState } from "react";
 
 interface ProductBoxProps {
   productData: any;
@@ -13,6 +14,7 @@ function getLocalizedText(value: any) {
 }
 
 const ProductBox: React.FC<ProductBoxProps> = ({ productData }) => {
+  const [isFlipped, setIsFlipped] = useState(false);
   let product = productData?.data || productData?.value?.data;
 
   const image = product?.images?.[0];
@@ -22,30 +24,118 @@ const ProductBox: React.FC<ProductBoxProps> = ({ productData }) => {
     return null;
   }
 
+  const handleAddToCart = (e: React.MouseEvent) => {
+    e.preventDefault();
+    console.log("Added to cart:", productName);
+  };
+
   return (
-    <a className="block w-full" href={`/product/${product?.handle}`}>
-      <div className="w-full h-[300px] border border-zinc-300 rounded-md overflow-hidden relative">
-        <Image
-          src={image.image}
-          alt={image.altText || productName || "Product image"}
-          fill={true}
-          style={{ objectFit: "cover" }}
-          loading="lazy"
-          sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 400px"
-        />
-      </div>
-      <div className="flex flex-col mt-3 w-full">
-        <div className="flex gap-3 justify-between w-full text-black text-left">
-          <div className="text-ellipsis overflow-hidden break-words">
-            {productName}
+    <div className="w-full">
+      <style>{`
+        @keyframes flipCard {
+          from {
+            transform: rotateY(0deg);
+          }
+          to {
+            transform: rotateY(180deg);
+          }
+        }
+        @keyframes flipCardBack {
+          from {
+            transform: rotateY(180deg);
+          }
+          to {
+            transform: rotateY(0deg);
+          }
+        }
+        .flip-container {
+          perspective: 1000px;
+          cursor: pointer;
+        }
+        .flip-inner {
+          position: relative;
+          width: 100%;
+          height: 300px;
+          transition: transform 0.6s;
+          transform-style: preserve-3d;
+        }
+        .flip-inner.flipped {
+          animation: flipCard 0.6s ease-in-out forwards;
+        }
+        .flip-inner.unflipped {
+          animation: flipCardBack 0.6s ease-in-out forwards;
+        }
+        .flip-front, .flip-back {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          backface-visibility: hidden;
+          display: flex;
+          flex-direction: column;
+          justify-content: flex-end;
+          border: 1px solid rgb(212, 212, 216);
+          border-radius: 0.375rem;
+          overflow: hidden;
+        }
+        .flip-back {
+          transform: rotateY(180deg);
+          background: white;
+          padding: 1.5rem;
+        }
+        .flip-back-content {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          gap: 1rem;
+          width: 100%;
+        }
+      `}</style>
+
+      <div
+        className="flip-container"
+        onMouseEnter={() => setIsFlipped(true)}
+        onMouseLeave={() => setIsFlipped(false)}
+      >
+        <div className={`flip-inner ${isFlipped ? "flipped" : "unflipped"}`}>
+          <div className="flip-front">
+            <Image
+              src={image.image}
+              alt={image.altText || productName || "Product image"}
+              fill={true}
+              style={{ objectFit: "cover" }}
+              loading="lazy"
+              sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 400px"
+            />
           </div>
-          <p className="font-semibold">${product?.price}</p>
+
+          <div className="flip-back">
+            <div className="flip-back-content">
+              <div className="text-center">
+                <p className="font-semibold text-lg text-black">
+                  ${product?.price}
+                </p>
+              </div>
+              <button
+                onClick={handleAddToCart}
+                className="w-full px-4 py-2 bg-black text-white rounded-md hover:bg-gray-800 transition-colors text-sm font-medium"
+              >
+                Add to Cart
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col mt-3 w-full">
+        <div className="text-ellipsis overflow-hidden break-words text-black text-left">
+          {productName}
         </div>
         <p className="mt-1 text-left text-stone-500">
           {product?.colors?.[0]?.label}
         </p>
       </div>
-    </a>
+    </div>
   );
 };
 


### PR DESCRIPTION
### Summary
Adds a 3D flip animation to product cards that reveals price and an "Add to Cart" button on hover, while keeping the product name below the card at all times.

### Problem
Product cards were static, only linking to the product page and showing the image, name, and price together. There was no interactive way to surface pricing or a quick add-to-cart action without navigating away from the listing.

### Solution
Replaced the anchor-wrapped static card with a hover-triggered flip container using CSS 3D transforms. The front face shows the product image, and the back face (revealed on hover) shows the price and an "Add to Cart" button. Product name remains displayed underneath the card outside the flip container.

### Key Changes
- Added `isFlipped` state to `ProductBox` to track hover state via `onMouseEnter`/`onMouseLeave`.
- Introduced CSS keyframe animations (`flipCard`, `flipCardBack`) and supporting classes (`flip-container`, `flip-inner`, `flip-front`, `flip-back`, `flip-back-content`) for the 3D flip effect using `perspective`, `transform-style: preserve-3d`, and `backface-visibility`.
- Front face renders the existing product image; back face renders the price and a new "Add to Cart" button.
- Added `handleAddToCart` click handler (currently logs the action) on the new button.
- Restructured markup: removed the outer `<a>` link wrapper in favor of a `<div>`, moved product name to its own block below the flip card, and removed price from the name row since it now appears on the card back.


---

<a href="https://builder.io/app/projects/3b9fc7c601564aab9df9/emerald-fang-elaxvsde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://3b9fc7c601564aab9df9-emerald-fang-elaxvsde.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=3b9fc7c601564aab9df9&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 107`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3b9fc7c601564aab9df9</projectId>-->
<!--<branchName>emerald-fang-elaxvsde</branchName>-->