### PR TITLE
Add HeroCarousel component with drag-and-drop hero slides

### DIFF
--- a/ecommerce/src/builder-registry.ts
+++ b/ecommerce/src/builder-registry.ts
@@ -8,6 +8,7 @@ import BynderImage from "./components/Blocks/BynderImage";
 import CloudinaryImage from "./components/Blocks/CloudinaryImage";
 import { Collection } from "./components/Collection/Collection";
 import Counter from "./components/Counter/Counter";
+import HeroCarousel from "./components/HeroCarousel/HeroCarousel";
 import HeroWithChildren from "./components/Hero/HeroWithChildren";
 import IconCard from "./components/Card/IconCard";
 import ImageHero from "./components/Hero/ImageHero";
@@ -77,6 +78,7 @@ Builder.register("insertMenu", {
     { name: "ImageHero" },
     { name: "SplitHero" },
     { name: "HeroWithChildren" },
+    { name: "HeroCarousel" },
   ],
   // priority: 2,
 });
@@ -394,6 +396,39 @@ Builder.registerComponent(ImageHero, {
       name: "makeFullBleed",
       type: "boolean",
       defaultValue: false,
+    },
+  ],
+});
+
+Builder.registerComponent(HeroCarousel, {
+  name: "HeroCarousel",
+  friendlyName: "Hero Carousel",
+  canHaveChildren: true,
+  image:
+    "https://cdn.builder.io/api/v1/image/assets%2FagZ9n5CUKRfbL9t6CaJOyVSK4Es2%2Fd909a5b91650499c9e0524cc904eeb77",
+  defaultChildren: [],
+  childRequirements: {
+    message: "You can only put Hero components inside a Hero Carousel",
+    query: {
+      "component.name": {
+        $in: ["TextHero", "ImageHero", "SplitHero", "HeroWithChildren"],
+      },
+    },
+  },
+  inputs: [
+    {
+      name: "carouselName",
+      friendlyName: "Carousel Name",
+      type: "string",
+      defaultValue: "Hero Carousel",
+      required: true,
+    },
+    {
+      name: "autoAdvanceSeconds",
+      friendlyName: "Auto-Advance Timer (seconds)",
+      helperText: "Set to 0 to disable auto-advance",
+      type: "number",
+      defaultValue: 0,
     },
   ],
 });

--- a/ecommerce/src/components/Gallery/Gallery.tsx
+++ b/ecommerce/src/components/Gallery/Gallery.tsx
@@ -11,6 +11,7 @@ import ProductCard from "@/src/components/Card/ProductCard";
 import { Collection } from "@/src/components/Collection/Collection";
 import Counter from "@/src/components/Counter/Counter";
 import CustomText from "@/src/components/CustomText";
+import HeroCarousel from "@/src/components/HeroCarousel/HeroCarousel";
 import HeroWithChildren from "@/src/components/Hero/HeroWithChildren";
 import ImageHero from "@/src/components/Hero/ImageHero";
 import SplitHero from "@/src/components/Hero/SplitHero";
@@ -45,7 +46,7 @@ const sampleProduct = {
 const navSections = [
   {
     title: "Heros",
-    items: ["ImageHero", "SplitHero", "TextHero", "HeroWithChildren"],
+    items: ["ImageHero", "SplitHero", "TextHero", "HeroWithChildren", "HeroCarousel"],
   },
   {
     title: "Cards",
@@ -163,7 +164,7 @@ export default function Gallery() {
               </p>
             </div>
             <span className="w-fit rounded-full border border-zinc-300 px-3 py-1 text-xs text-zinc-600">
-              15 components
+              16 components
             </span>
           </div>
         </div>
@@ -229,6 +230,15 @@ export default function Gallery() {
             childBlocks={[]}
             makeFullBleed={false}
           />
+        </ComponentSection>
+
+        <ComponentSection
+          name="HeroCarousel"
+          group="Heros"
+          description="Empty carousel shell that Hero components can be dragged into. Renders dots and arrows for navigation and supports a configurable name and auto-advance timer."
+          inputs="carouselName, autoAdvanceSeconds"
+        >
+          <HeroCarousel carouselName="Homepage Hero Carousel" autoAdvanceSeconds={5} />
         </ComponentSection>
 
         <ComponentSection

--- a/ecommerce/src/components/HeroCarousel/HeroCarousel.tsx
+++ b/ecommerce/src/components/HeroCarousel/HeroCarousel.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { BuilderBlockComponent } from "@builder.io/react";
+
+interface HeroCarouselProps {
+  carouselName?: string;
+  autoAdvanceSeconds?: number;
+  builderBlock?: any;
+}
+
+const HeroCarousel: React.FC<HeroCarouselProps> = (props) => {
+  const slides = props.builderBlock?.children || [];
+  const slideCount = slides.length;
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (activeIndex >= slideCount) {
+      setActiveIndex(0);
+    }
+  }, [slideCount, activeIndex]);
+
+  useEffect(() => {
+    if (!props.autoAdvanceSeconds || props.autoAdvanceSeconds <= 0 || slideCount <= 1) {
+      return;
+    }
+    const timer = setInterval(() => {
+      setActiveIndex((prev) => (prev + 1) % slideCount);
+    }, props.autoAdvanceSeconds * 1000);
+    return () => clearInterval(timer);
+  }, [props.autoAdvanceSeconds, slideCount]);
+
+  const goTo = (index: number) => {
+    setActiveIndex(((index % slideCount) + slideCount) % slideCount);
+  };
+
+  return (
+    <div
+      className="relative w-full overflow-hidden"
+      aria-roledescription="carousel"
+      aria-label={props.carouselName || "Carousel"}
+    >
+      {slideCount === 0 ? (
+        <div className="flex min-h-[320px] w-full items-center justify-center border-2 border-dashed border-zinc-300 bg-zinc-50 text-center text-sm text-zinc-500">
+          Drag a hero component here to add a slide to &ldquo;
+          {props.carouselName || "Carousel"}&rdquo;
+        </div>
+      ) : (
+        <div
+          className="flex transition-transform duration-500 ease-in-out"
+          style={{ transform: `translateX(-${activeIndex * 100}%)` }}
+        >
+          {slides.map((block: any, index: number) => (
+            <div key={block.id || index} className="w-full shrink-0">
+              <BuilderBlockComponent block={block} index={index} child />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {slideCount > 1 && (
+        <>
+          <button
+            type="button"
+            onClick={() => goTo(activeIndex - 1)}
+            aria-label="Previous slide"
+            className="absolute left-4 top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-lg text-black shadow hover:bg-white"
+          >
+            ‹
+          </button>
+          <button
+            type="button"
+            onClick={() => goTo(activeIndex + 1)}
+            aria-label="Next slide"
+            className="absolute right-4 top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-lg text-black shadow hover:bg-white"
+          >
+            ›
+          </button>
+          <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 gap-2 rounded-full bg-black/30 px-3 py-2">
+            {slides.map((_: any, index: number) => (
+              <button
+                key={index}
+                type="button"
+                onClick={() => goTo(index)}
+                aria-label={`Go to slide ${index + 1}`}
+                aria-current={index === activeIndex}
+                className={`h-2.5 w-2.5 rounded-full transition-colors ${
+                  index === activeIndex ? "bg-white" : "bg-white/50 hover:bg-white/75"
+                }`}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default HeroCarousel;


### PR DESCRIPTION
### Summary
Adds a new `HeroCarousel` component that acts as an empty shell for dragging in Hero components as slides, complete with dot/arrow navigation, and registers it with the Builder CMS and component gallery.

### Problem
There was no way to build a rotating hero carousel from within the builder CMS. Editors had no shell component that could accept multiple Hero components as slides and cycle through them with configurable naming and auto-advance behavior.

### Solution
Created a `HeroCarousel` component that renders Builder block children as slides, tracks the active slide in state, and optionally auto-advances on a configurable interval. The component starts empty and only accepts Hero-type components as children, restricted via `childRequirements`. It was then wired into the Builder registry and added to the component gallery for discoverability.

### Key Changes
- New `HeroCarousel.tsx` component that renders `builderBlock` children as slides using `BuilderBlockComponent`, with previous/next arrow buttons and clickable dot indicators
- Auto-advance support via `autoAdvanceSeconds` prop, using `setInterval` and cycling through slides (disabled when set to 0 or with a single slide)
- Empty-state placeholder shown when no slides have been added yet, prompting drag-and-drop of Hero components
- Registered `HeroCarousel` in `builder-registry.ts` with `carouselName` and `autoAdvanceSeconds` inputs, `canHaveChildren: true`, and `childRequirements` restricting children to `TextHero`, `ImageHero`, `SplitHero`, and `HeroWithChildren`
- Added `HeroCarousel` to the insert menu under Heros
- Added `HeroCarousel` entry to the component `Gallery.tsx` with sample usage and updated component count from 15 to 16


---

<a href="https://builder.io/app/projects/3b9fc7c601564aab9df9/neon-portal-r5j6ehsp"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://3b9fc7c601564aab9df9-neon-portal-r5j6ehsp.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=3b9fc7c601564aab9df9&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 108`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3b9fc7c601564aab9df9</projectId>-->
<!--<branchName>neon-portal-r5j6ehsp</branchName>-->