### PR TITLE
Add Carousel component with slide navigation and auto-advance

### DIFF
--- a/ecommerce/src/builder-registry.ts
+++ b/ecommerce/src/builder-registry.ts
@@ -6,6 +6,7 @@ import AlgoliaSearchBox from "./components/AlgoliaSearchBox/AlgoliaSearchBox";
 import { Button } from "./components/ui/button";
 import BynderImage from "./components/Blocks/BynderImage";
 import CloudinaryImage from "./components/Blocks/CloudinaryImage";
+import Carousel from "./components/Carousel/Carousel";
 import { Collection } from "./components/Collection/Collection";
 import Counter from "./components/Counter/Counter";
 import HeroWithChildren from "./components/Hero/HeroWithChildren";
@@ -77,6 +78,7 @@ Builder.register("insertMenu", {
     { name: "ImageHero" },
     { name: "SplitHero" },
     { name: "HeroWithChildren" },
+    { name: "Carousel" },
   ],
   // priority: 2,
 });
@@ -428,6 +430,35 @@ Builder.registerComponent(withChildren(HeroWithChildren), {
       type: "boolean",
       defaultValue: false,
       broadcast: true,
+    },
+  ],
+});
+
+Builder.registerComponent(withChildren(Carousel), {
+  name: "Carousel",
+  friendlyName: "Carousel",
+  canHaveChildren: true,
+  defaultChildren: [],
+  image: "https://api.iconify.design/mdi:view-carousel.svg?color=%23000000",
+  inputs: [
+    {
+      name: "name",
+      friendlyName: "Carousel Name",
+      type: "string",
+      defaultValue: "Carousel",
+    },
+    {
+      name: "autoAdvance",
+      friendlyName: "Auto-advance",
+      type: "boolean",
+      defaultValue: true,
+    },
+    {
+      name: "autoAdvanceInterval",
+      friendlyName: "Auto-advance interval (ms)",
+      type: "number",
+      defaultValue: 5000,
+      showIf: (options: any) => options.get("autoAdvance") == true,
     },
   ],
 });

--- a/ecommerce/src/components/Carousel/Carousel.tsx
+++ b/ecommerce/src/components/Carousel/Carousel.tsx
@@ -1,0 +1,110 @@
+"use client";
+import React, { useEffect, useRef, useState } from "react";
+
+interface CarouselProps {
+  name?: string;
+  autoAdvance?: boolean;
+  autoAdvanceInterval?: number;
+  children?: React.ReactNode;
+}
+
+const Carousel: React.FC<CarouselProps> = ({
+  name = "Carousel",
+  autoAdvance = true,
+  autoAdvanceInterval = 5000,
+  children,
+}) => {
+  const slides = React.Children.toArray(children);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setInterval>>();
+
+  const goTo = (index: number) => {
+    setActiveIndex(((index % slides.length) + slides.length) % slides.length);
+  };
+
+  useEffect(() => {
+    if (activeIndex >= slides.length) {
+      setActiveIndex(0);
+    }
+  }, [slides.length, activeIndex]);
+
+  useEffect(() => {
+    if (!autoAdvance || slides.length <= 1) {
+      return;
+    }
+    timerRef.current = setInterval(() => {
+      setActiveIndex((current) => (current + 1) % slides.length);
+    }, Math.max(autoAdvanceInterval, 1000));
+    return () => clearInterval(timerRef.current);
+  }, [autoAdvance, autoAdvanceInterval, slides.length]);
+
+  if (slides.length === 0) {
+    return (
+      <div className="flex min-h-[240px] w-full items-center justify-center border border-dashed border-zinc-300 bg-zinc-50 text-center text-sm text-zinc-500">
+        Drag Hero components here to build the &ldquo;{name}&rdquo; carousel
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative w-full overflow-hidden"
+      role="region"
+      aria-roledescription="carousel"
+      aria-label={name}
+    >
+      <div
+        className="flex transition-transform duration-500 ease-in-out"
+        style={{ transform: `translateX(-${activeIndex * 100}%)` }}
+      >
+        {slides.map((slide, index) => (
+          <div
+            key={index}
+            className="w-full flex-shrink-0"
+            aria-hidden={index !== activeIndex}
+          >
+            {slide}
+          </div>
+        ))}
+      </div>
+
+      {slides.length > 1 && (
+        <>
+          <button
+            type="button"
+            aria-label="Previous slide"
+            onClick={() => goTo(activeIndex - 1)}
+            className="absolute left-3 top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-black shadow hover:bg-white"
+          >
+            &#8249;
+          </button>
+          <button
+            type="button"
+            aria-label="Next slide"
+            onClick={() => goTo(activeIndex + 1)}
+            className="absolute right-3 top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 text-black shadow hover:bg-white"
+          >
+            &#8250;
+          </button>
+
+          <div className="absolute bottom-3 left-1/2 flex -translate-x-1/2 gap-2">
+            {slides.map((_, index) => (
+              <button
+                key={index}
+                type="button"
+                aria-label={`Go to slide ${index + 1}`}
+                aria-current={index === activeIndex}
+                onClick={() => goTo(index)}
+                className={`h-2.5 w-2.5 rounded-full transition-colors ${
+                  index === activeIndex ? "bg-white" : "bg-white/50"
+                }`}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default Carousel;

--- a/ecommerce/src/components/Gallery/Gallery.tsx
+++ b/ecommerce/src/components/Gallery/Gallery.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import Accordion from "@/src/components/Accordion/accordion";
 import AlgoliaSearchBox from "@/src/components/AlgoliaSearchBox/AlgoliaSearchBox";
 import BynderImage from "@/src/components/Blocks/BynderImage";
+import Carousel from "@/src/components/Carousel/Carousel";
 import CloudinaryImage from "@/src/components/Blocks/CloudinaryImage";
 import IconCard from "@/src/components/Card/IconCard";
 import ProductCard from "@/src/components/Card/ProductCard";
@@ -45,7 +46,7 @@ const sampleProduct = {
 const navSections = [
   {
     title: "Heros",
-    items: ["ImageHero", "SplitHero", "TextHero", "HeroWithChildren"],
+    items: ["ImageHero", "SplitHero", "TextHero", "HeroWithChildren", "Carousel"],
   },
   {
     title: "Cards",
@@ -163,7 +164,7 @@ export default function Gallery() {
               </p>
             </div>
             <span className="w-fit rounded-full border border-zinc-300 px-3 py-1 text-xs text-zinc-600">
-              15 components
+              16 components
             </span>
           </div>
         </div>
@@ -229,6 +230,31 @@ export default function Gallery() {
             childBlocks={[]}
             makeFullBleed={false}
           />
+        </ComponentSection>
+
+        <ComponentSection
+          name="Carousel"
+          group="Heros"
+          description="Empty shell that other components (typically Hero sections) can be dragged into as slides, with dot and arrow navigation and a configurable auto-advance timer."
+          inputs="name, autoAdvance, autoAdvanceInterval, children"
+        >
+          <div className="h-80">
+            <Carousel name="Homepage Carousel" autoAdvance={false} autoAdvanceInterval={5000}>
+              <TextHero
+                title="STEP INTO FRESH STYLES"
+                subTitle="<p>Lightweight layers, polished basics, and accessories made for everyday wear.</p>"
+              />
+              <ImageHero
+                title="SHOP ESSENTIALS"
+                subTitle="<p>Shoppable essentials for your every day life.</p>"
+                buttonText="Shop Now"
+                buttonLink="/category/accessories"
+                backgroundImage={heroImage}
+                alignment="center"
+                makeFullBleed={false}
+              />
+            </Carousel>
+          </div>
         </ComponentSection>
 
         <ComponentSection


### PR DESCRIPTION
### Summary
Adds a new `Carousel` component that acts as an empty shell for dragging in other components (such as Hero sections) as slides, complete with dot/arrow navigation and a configurable auto-advance timer.

### Problem
There was no way to combine multiple hero sections into a single rotating carousel within the builder CMS. Editors needed a flexible container component that could hold any dragged-in children as slides, with built-in navigation controls and auto-advance behavior configurable directly in the CMS.

### Solution
Implemented a `Carousel` React component that renders its children as slides, tracks the active slide index, and provides previous/next arrow buttons plus dot indicators for navigation. The component starts empty with a placeholder prompting users to drag in content, and supports an optional auto-advance timer. It was then registered with Builder.io as a droppable component with configurable inputs, added to the insert menu, and showcased in the component gallery.

### Key Changes
- Created `Carousel.tsx` component that renders `children` as slides, manages active slide state, and supports looping navigation via `goTo`
- Added previous/next arrow buttons and clickable dot indicators, shown only when there is more than one slide
- Added an empty-state placeholder with the carousel's configurable name when no children are present
- Implemented auto-advance via `setInterval`, configurable through `autoAdvance` and `autoAdvanceInterval` props (minimum 1000ms)
- Registered `Carousel` in `builder-registry.ts` using `withChildren`, with `canHaveChildren: true`, an empty `defaultChildren`, and inputs for `name`, `autoAdvance`, and `autoAdvanceInterval` (the interval input only shows when auto-advance is enabled)
- Added `Carousel` to the Builder.io insert menu
- Added `Carousel` to the component `Gallery` under the "Heros" group, including a live demo nesting `TextHero` and `ImageHero` slides, and updated the total component count to 16


---

<a href="https://builder.io/app/projects/3b9fc7c601564aab9df9/lightning-gateway-a2jxflxq"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://3b9fc7c601564aab9df9-lightning-gateway-a2jxflxq.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=3b9fc7c601564aab9df9&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 109`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3b9fc7c601564aab9df9</projectId>-->
<!--<branchName>lightning-gateway-a2jxflxq</branchName>-->