### PR TITLE
Add flip animation to product cards and new Carousel component

### DIFF
--- a/ecommerce/src/builder-registry.ts
+++ b/ecommerce/src/builder-registry.ts
@@ -16,6 +16,7 @@ import SplitHero from "./components/Hero/SplitHero";
 import TextHero from "./components/Hero/TextHero";
 import UpsellPopup from "./components/Popup/UpsellPopup";
 import CustomText from "./components/CustomText";
+import Carousel from "./components/Hero/Carousel";
 
 builder.init(process.env.NEXT_PUBLIC_BUILDER_API_KEY!);
 
@@ -77,6 +78,7 @@ Builder.register("insertMenu", {
     { name: "ImageHero" },
     { name: "SplitHero" },
     { name: "HeroWithChildren" },
+    { name: "Carousel" },
   ],
   // priority: 2,
 });
@@ -601,6 +603,32 @@ Builder.registerComponent(CustomText, {
         { name: "target", type: "string", enum: ["_blank", "_self"] },
         { name: "rel", type: "string" },
       ],
+    },
+  ],
+});
+
+Builder.registerComponent(withChildren(Carousel), {
+  name: "Carousel",
+  canHaveChildren: true,
+  image:
+    "https://cdn.builder.io/api/v1/image/assets%2Fa87584e551b6472fa0f0a2eb10f2c0ff%2F2bbe97f46ba14868a6925faf5cbb8d18",
+  inputs: [
+    {
+      name: "name",
+      type: "string",
+      defaultValue: "Carousel",
+    },
+    {
+      name: "autoAdvanceTimer",
+      type: "number",
+      defaultValue: 0,
+      helperText: "Auto-advance to next slide in seconds (0 = disabled)",
+    },
+    {
+      name: "children",
+      type: "uiBlocks",
+      hideFromUI: true,
+      defaultValue: [],
     },
   ],
 });

--- a/ecommerce/src/components/Gallery/Gallery.tsx
+++ b/ecommerce/src/components/Gallery/Gallery.tsx
@@ -17,6 +17,7 @@ import SplitHero from "@/src/components/Hero/SplitHero";
 import TextHero from "@/src/components/Hero/TextHero";
 import UpsellPopup from "@/src/components/Popup/UpsellPopup";
 import { Button } from "@/src/components/ui/button";
+import Carousel from "@/src/components/Hero/Carousel";
 
 const heroImage =
   "https://cdn.builder.io/api/v1/image/assets%2Fa87584e551b6472fa0f0a2eb10f2c0ff%2F61c4f304ac9448b1ad741b83de17e48a";
@@ -45,7 +46,7 @@ const sampleProduct = {
 const navSections = [
   {
     title: "Heros",
-    items: ["ImageHero", "SplitHero", "TextHero", "HeroWithChildren"],
+    items: ["ImageHero", "SplitHero", "TextHero", "HeroWithChildren", "Carousel"],
   },
   {
     title: "Cards",
@@ -228,6 +229,18 @@ export default function Gallery() {
             header="WHAT'S DIFFERENT ABOUT SHOPAHOLIC"
             childBlocks={[]}
             makeFullBleed={false}
+          />
+        </ComponentSection>
+
+        <ComponentSection
+          name="Carousel"
+          group="Heros"
+          description="Carousel shell component that accepts hero sections as slides. Features auto-advance timer, navigation dots, and prev/next arrows."
+          inputs="name, autoAdvanceTimer, children"
+        >
+          <Carousel
+            name="Carousel"
+            autoAdvanceTimer={0}
           />
         </ComponentSection>
 

--- a/ecommerce/src/components/Hero/Carousel.tsx
+++ b/ecommerce/src/components/Hero/Carousel.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+
+interface CarouselProps {
+  name?: string;
+  autoAdvanceTimer?: number;
+  children?: React.ReactNode;
+}
+
+const Carousel: React.FC<CarouselProps> = ({ 
+  name = "Carousel",
+  autoAdvanceTimer = 0,
+  children 
+}) => {
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const childArray = React.Children.toArray(children);
+
+  useEffect(() => {
+    if (autoAdvanceTimer && autoAdvanceTimer > 0 && childArray.length > 0) {
+      const interval = setInterval(() => {
+        setCurrentSlide((prev) => (prev + 1) % childArray.length);
+      }, autoAdvanceTimer * 1000);
+      return () => clearInterval(interval);
+    }
+  }, [autoAdvanceTimer, childArray.length]);
+
+  const nextSlide = () => {
+    if (childArray.length > 0) {
+      setCurrentSlide((prev) => (prev + 1) % childArray.length);
+    }
+  };
+
+  const prevSlide = () => {
+    if (childArray.length > 0) {
+      setCurrentSlide((prev) => (prev - 1 + childArray.length) % childArray.length);
+    }
+  };
+
+  return (
+    <div className="w-full">
+      <div className="relative w-full overflow-hidden rounded-lg bg-gray-100 min-h-96">
+        {childArray.length === 0 ? (
+          <div className="flex items-center justify-center h-96 text-gray-500">
+            <p>Drag hero sections here to create slides</p>
+          </div>
+        ) : (
+          <div className="relative w-full h-full">
+            {childArray.map((child, index) => (
+              <div
+                key={index}
+                className={`absolute inset-0 transition-opacity duration-500 ${
+                  index === currentSlide ? 'opacity-100' : 'opacity-0'
+                }`}
+              >
+                {child}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {childArray.length > 0 && (
+        <div className="flex items-center justify-center gap-6 mt-6">
+          <button
+            onClick={prevSlide}
+            className="p-2 hover:bg-gray-200 rounded-full transition-colors"
+            aria-label="Previous slide"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+
+          <div className="flex gap-2">
+            {childArray.map((_, index) => (
+              <button
+                key={index}
+                onClick={() => setCurrentSlide(index)}
+                className={`w-3 h-3 rounded-full transition-colors ${
+                  index === currentSlide ? 'bg-black' : 'bg-gray-300'
+                }`}
+                aria-label={`Go to slide ${index + 1}`}
+              />
+            ))}
+          </div>
+
+          <button
+            onClick={nextSlide}
+            className="p-2 hover:bg-gray-200 rounded-full transition-colors"
+            aria-label="Next slide"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Carousel;

--- a/ecommerce/src/components/Hero/TextHero.tsx
+++ b/ecommerce/src/components/Hero/TextHero.tsx
@@ -11,7 +11,7 @@ interface TextHeroProps {
 const TextHero: React.FC<TextHeroProps> = ({ title, subTitle }) => {
   return (
     <div className="flex flex-col justify-center px-16 mt-8 w-full text-gray-800 max-md:px-5 max-md:max-w-full">
-      <h2 className="self-center text-2xl text-black leading-8">{title}</h2>
+      <h2 className="self-center text-2xl leading-8" style={{ color: 'rgba(173, 20, 20, 1)' }}>{title}</h2>
       <div className="mt-3 text-lg leading-8 text-center max-md:max-w-full" dangerouslySetInnerHTML={{ __html: subTitle || "" }}></div>
     </div>
   );

--- a/ecommerce/src/components/ui/productBox.tsx
+++ b/ecommerce/src/components/ui/productBox.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import Image from "next/image";
+import { useState } from "react";
 
 interface ProductBoxProps {
   productData: any;
@@ -13,6 +16,7 @@ function getLocalizedText(value: any) {
 }
 
 const ProductBox: React.FC<ProductBoxProps> = ({ productData }) => {
+  const [isFlipped, setIsFlipped] = useState(false);
   let product = productData?.data || productData?.value?.data;
 
   const image = product?.images?.[0];
@@ -23,29 +27,107 @@ const ProductBox: React.FC<ProductBoxProps> = ({ productData }) => {
   }
 
   return (
-    <a className="block w-full" href={`/product/${product?.handle}`}>
-      <div className="w-full h-[300px] border border-zinc-300 rounded-md overflow-hidden relative">
-        <Image
-          src={image.image}
-          alt={image.altText || productName || "Product image"}
-          fill={true}
-          style={{ objectFit: "cover" }}
-          loading="lazy"
-          sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 400px"
-        />
+    <div className="w-full h-[300px] perspective">
+      <style>{`
+        @keyframes flipCard {
+          from {
+            transform: rotateY(0deg);
+          }
+          to {
+            transform: rotateY(180deg);
+          }
+        }
+
+        @keyframes flipCardBack {
+          from {
+            transform: rotateY(180deg);
+          }
+          to {
+            transform: rotateY(0deg);
+          }
+        }
+
+        .flip-container {
+          perspective: 1000px;
+          height: 100%;
+        }
+
+        .flip-inner {
+          position: relative;
+          width: 100%;
+          height: 100%;
+          transition: transform 0.6s;
+          transform-style: preserve-3d;
+        }
+
+        .flip-container.flipped .flip-inner {
+          transform: rotateY(180deg);
+        }
+
+        .flip-front,
+        .flip-back {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          backface-visibility: hidden;
+          border-radius: 0.375rem;
+          border: 1px solid #e4e4e7;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+        }
+
+        .flip-back {
+          transform: rotateY(180deg);
+          background: white;
+        }
+      `}</style>
+
+      <div
+        className={`flip-container ${isFlipped ? 'flipped' : ''}`}
+        onMouseEnter={() => setIsFlipped(true)}
+        onMouseLeave={() => setIsFlipped(false)}
+      >
+        <div className="flip-inner">
+          <div className="flip-front overflow-hidden relative">
+            <Image
+              src={image.image}
+              alt={image.altText || productName || "Product image"}
+              fill={true}
+              style={{ objectFit: "cover" }}
+              loading="lazy"
+              sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 400px"
+            />
+          </div>
+
+          <div className="flip-back">
+            <div className="w-full h-full flex flex-col justify-between p-6 text-center">
+              <p className="font-semibold text-2xl text-black">
+                ${product?.price}
+              </p>
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  setIsFlipped(false);
+                }}
+                className="bg-black text-white px-6 py-2 rounded hover:bg-gray-800 transition-colors"
+              >
+                Add to Cart
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
-      <div className="flex flex-col mt-3 w-full">
+
+      <a className="block w-full mt-3" href={`/product/${product?.handle}`}>
         <div className="flex gap-3 justify-between w-full text-black text-left">
           <div className="text-ellipsis overflow-hidden break-words">
             {productName}
           </div>
-          <p className="font-semibold">${product?.price}</p>
         </div>
-        <p className="mt-1 text-left text-stone-500">
-          {product?.colors?.[0]?.label}
-        </p>
-      </div>
-    </a>
+      </a>
+    </div>
   );
 };
 


### PR DESCRIPTION
### Summary
Adds a hover flip animation to product cards revealing price/add-to-cart on the back, and introduces a new configurable Carousel shell component registered in the Builder CMS and component gallery.

### Problem
Product cards were static, only showing image, name, price, and color with no interactivity. Additionally, there was no way to build a carousel by dragging hero sections into slides, with navigation and auto-advance controls configurable in the CMS.

### Solution
- Reworked `ProductBox` to use a CSS 3D flip animation triggered on hover, showing the image and name on the front and price plus an "Add to Cart" button on the back.
- Built a new `Carousel` component that acts as a drag-and-drop shell for hero sections, with navigation dots, prev/next arrows, and an optional auto-advance timer. Registered it with Builder CMS and added it to the component gallery.

### Key Changes
- `ecommerce/src/components/ui/productBox.tsx`: Added flip-card CSS/animations and hover state (`isFlipped`) to reveal price and "Add to Cart" button on the back of the card; kept product name/link on the front.
- `ecommerce/src/components/Hero/Carousel.tsx`: New component that renders children as slides, supports auto-advance via `autoAdvanceTimer` prop, and includes dot navigation plus prev/next arrow controls; shows placeholder text when empty.
- `ecommerce/src/builder-registry.ts`: Registered `Carousel` with `withChildren`, added it to the insert menu, and configured `name`, `autoAdvanceTimer`, and `children` (uiBlocks) inputs.
- `ecommerce/src/components/Gallery/Gallery.tsx`: Added `Carousel` to the "Heros" navigation section and a corresponding `ComponentSection` demo entry.
- `ecommerce/src/components/Hero/TextHero.tsx`: Minor style tweak, changing the title text color to a custom red.


---

<a href="https://builder.io/app/projects/3b9fc7c601564aab9df9/wizard-record-6arysyzc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://3b9fc7c601564aab9df9-wizard-record-6arysyzc.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=3b9fc7c601564aab9df9&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 110`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3b9fc7c601564aab9df9</projectId>-->
<!--<branchName>wizard-record-6arysyzc</branchName>-->